### PR TITLE
Added logstash config for hadoop config resource location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Important: the Hadoop configuration dir containing `hdfs-site.xml` must be on th
 
 Config options are basically the same as the file output, but have a look at the `doc/` directory for specfics. 
 
+HDFS Configuration
+=============
+By default, the plugin will use Hadoop's default configuration location.  However, a logstash configuration option named 'hadoop_config_resources' has
+been added that will allow the user to pass in multiple configuration classpath locations to override this default configuration.
+
+    output {
+            hdfs {
+                path => "/path/to/output_file.log"
+                hadoop_config_resources => ['path/to/configuration/on/classpath/hdfs-site.xml']
+            }
+        }
+
+
 HDFS Append and rewriting files
 =============
 Please note, HDFS versions prior to 2.x do not properly support append. See [HADOOP-8230](https://issues.apache.org/jira/browse/HADOOP-8230) for reference.

--- a/logstash/outputs/hdfs.rb
+++ b/logstash/outputs/hdfs.rb
@@ -32,6 +32,9 @@ class LogStash::Outputs::HDFS < LogStash::Outputs::Base
   # Enable re-opening files. This is a really a bad idea because HDFS will truncate files. Only use if you know what you're doing
   config :enable_reopen, :validate => :boolean, :default => false
 
+  # The classpath resource locations of the hadoop configuration
+  config :hadoop_config_resources, :validate => :array
+
   public
   def register
     require "java"
@@ -46,6 +49,13 @@ class LogStash::Outputs::HDFS < LogStash::Outputs::Base
     flush_interval = @flush_interval.to_i
     @stale_cleanup_interval = 10
     conf = Configuration.new
+
+    if @hadoop_config_resources
+      @hadoop_config_resources.each { |resource|
+        conf.addResource(resource)
+      }
+    end
+
     @logger.info "Using Hadoop configuration: #{conf.get("fs.defaultFS")}"
     @hdfs = FileSystem.get(conf)
   end # def register


### PR DESCRIPTION
We need to be able to vary the location that hadoop looks for its configuration by environment without rebuilding our logstash instance.  This flag should allow us to do that easily, but is optional.
